### PR TITLE
Use single goroutine approach

### DIFF
--- a/cartesian.go
+++ b/cartesian.go
@@ -1,5 +1,6 @@
 package cartesian
 
+// Iter takes interface-slices and returns a channel, receiving cartesian products
 func Iter(params ...[]interface{}) chan []interface{} {
 	// create channel
 	c := make(chan []interface{})
@@ -15,12 +16,13 @@ func Iter(params ...[]interface{}) chan []interface{} {
 }
 
 func iterate(channel chan []interface{}, topLevel, result []interface{}, needUnpacking ...[]interface{}) {
-	for _, p := range topLevel {
-		newResult := append(append([]interface{}{}, result...), p)
-		if len(needUnpacking) == 0 {
-			channel <- newResult
-			continue
+	if len(needUnpacking) == 0 {
+		for _, p := range topLevel {
+			channel <- append(append([]interface{}{}, result...), p)
 		}
-		iterate(channel, needUnpacking[0], newResult, needUnpacking[1:]...)
+		return
+	}
+	for _, p := range topLevel {
+		iterate(channel, needUnpacking[0], append(result, p), needUnpacking[1:]...)
 	}
 }

--- a/cartesian.go
+++ b/cartesian.go
@@ -15,13 +15,12 @@ func Iter(params ...[]interface{}) chan []interface{} {
 }
 
 func iterate(channel chan []interface{}, topLevel, result []interface{}, needUnpacking ...[]interface{}) {
-	if len(needUnpacking) == 0 {
-		for _, p := range topLevel {
-			channel <- append(result, p)
-		}
-		return
-	}
 	for _, p := range topLevel {
-		iterate(channel, needUnpacking[0], append(result, p), needUnpacking[1:]...)
+		newResult := append(append([]interface{}{}, result...), p)
+		if len(needUnpacking) == 0 {
+			channel <- newResult
+			continue
+		}
+		iterate(channel, needUnpacking[0], newResult, needUnpacking[1:]...)
 	}
 }

--- a/cartesian_test.go
+++ b/cartesian_test.go
@@ -2,6 +2,7 @@ package cartesian_test
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/schwarmco/go-cartesian-product"
@@ -31,7 +32,6 @@ func ExampleIter() {
 }
 
 func TestIter(t *testing.T) {
-
 	// the sum on each index should be ( (1+2+3)/3 ) * 3 ^ 4
 	// meaning that the mean (2) should occur in every line (which are 81 in total)
 	var expected = 162
@@ -50,4 +50,62 @@ func TestIter(t *testing.T) {
 	if cnt0 != expected || cnt1 != expected || cnt2 != expected || cnt3 != expected {
 		t.Error("expected counter to be", expected, "got:", cnt0, cnt1, cnt2, cnt3)
 	}
+}
+
+func TestIterStress(t *testing.T) {
+	const max = 7
+	rng := rand.New(rand.NewSource(2))
+	for n := 1; n < max; n++ {
+		for m := 1; m < max; m++ {
+			for x := 1; x < max; x++ {
+				for y := 1; y < max; y++ {
+					for z := 1; z < max; z++ {
+						p0 := randomSlice(rng, n)
+						p1 := randomSlice(rng, m)
+						p2 := randomSlice(rng, x)
+						p3 := randomSlice(rng, y)
+						p4 := randomSlice(rng, z)
+
+						wantHashes := make(map[uint32]struct{})
+						for in := 0; in < n; in++ {
+							n0 := p0[in].(uint32)
+							for im := 0; im < m; im++ {
+								n1 := p1[im].(uint32)
+								for ix := 0; ix < x; ix++ {
+									n2 := p2[ix].(uint32)
+									for iy := 0; iy < y; iy++ {
+										n3 := p3[iy].(uint32)
+										for iz := 0; iz < z; iz++ {
+											n4 := p4[iz].(uint32)
+											sum := n0 + n1 + n2 + n3 + n4
+											wantHashes[sum] = struct{}{}
+										}
+									}
+								}
+							}
+						}
+
+						// We then check that we got that hash for every product we received.
+						for product := range cartesian.Iter(p0, p1, p2, p3, p4) {
+							sum := uint32(0)
+							for i := range product {
+								sum += product[i].(uint32)
+							}
+							if _, ok := wantHashes[sum]; !ok {
+								t.Error("unexpected product:", product)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func randomSlice(rng *rand.Rand, n int) []interface{} {
+	s := make([]interface{}, n)
+	for i := 0; i < n; i++ {
+		s[i] = rng.Uint32() % 4
+	}
+	return s
 }

--- a/cartesian_test.go
+++ b/cartesian_test.go
@@ -53,7 +53,7 @@ func TestIter(t *testing.T) {
 }
 
 func TestIterStress(t *testing.T) {
-	const max = 7
+	const max = 6
 	rng := rand.New(rand.NewSource(2))
 	for n := 1; n < max; n++ {
 		for m := 1; m < max; m++ {
@@ -105,7 +105,7 @@ func TestIterStress(t *testing.T) {
 func randomSlice(rng *rand.Rand, n int) []interface{} {
 	s := make([]interface{}, n)
 	for i := 0; i < n; i++ {
-		s[i] = rng.Uint32() % 4
+		s[i] = rng.Uint32()
 	}
 	return s
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/schwarmco/go-cartesian-product
+
+go 1.21.0


### PR DESCRIPTION
Hey- 
I'm still working on this. As of the PR it still does not pass tests.

This type of approach could potentially help with #2 since instead of having as many goroutines as combinations (which turns out can be **a lot**) we limit ourselves to 1 goroutine.

Also adds support for Go modules.